### PR TITLE
Xinit fix for where the application name has special characters

### DIFF
--- a/src/single-spa-alpinejs.js
+++ b/src/single-spa-alpinejs.js
@@ -54,6 +54,14 @@ function bootstrap(opts, props) {
 }
 
 /**
+ * Remove special characters from the string
+ * @param {*} str 
+ */
+function normalizeString(str) {
+  return (str && typeof str === "string")?str.replace(/[^a-z0-9,. ]/gi, '_'):'';
+}
+
+/**
  * Create the Alpine Element
  * @param {*} template - The final template
  * @param {*} opts     - alpine options
@@ -81,7 +89,7 @@ function createAlpineElement(template, opts, props) {
       childElement.id = `alpine-${props.name}`;
       childElement.innerHTML = template;
       const appName = props.appName || props.name;
-
+      const normalizedName = normalizeString(appName);
       // add x-data attribute
       childElement.setAttribute("x-data", JSON.stringify(finalData));
 
@@ -90,15 +98,15 @@ function createAlpineElement(template, opts, props) {
         // create any global x-init functions that are needed
         if (window.hasOwnProperty("singleSpaAlpineXInit")) {
           // add new x-init function globally for the specific ID
-          window.singleSpaAlpineXInit[appName] = opts.xInit;
+          window.singleSpaAlpineXInit[normalizedName] = opts.xInit;
         } else {
-          window.singleSpaAlpineXInit = { [appName]: opts.xInit };
+          window.singleSpaAlpineXInit = { [normalizedName]: opts.xInit };
         }
 
         // Add x-init attribute
         childElement.setAttribute(
           "x-init",
-          `singleSpaAlpineXInit.${appName}('alpine-${appName}')`
+          `singleSpaAlpineXInit.${normalizedName}('alpine-${appName}')`
         );
       }
 
@@ -157,6 +165,7 @@ function unmount(opts, props) {
   return Promise.resolve().then(() => {
     const domElementGetter = chooseDomElementGetter(opts, props);
     const appName = props.appName || props.name;
+    const normalizedName = normalizeString(appName);
     if (typeof domElementGetter !== "function") {
       throw new Error(
         `single-spa-alpinejs: the domElementGetter for application '${
@@ -180,13 +189,13 @@ function unmount(opts, props) {
     if (opts.xInit) {
       if (
         !window.hasOwnProperty("singleSpaAlpineXInit") ||
-        typeof window.singleSpaAlpineXInit[`${appName}`] === "undefined"
+        typeof window.singleSpaAlpineXInit[`${normalizedName}`] === "undefined"
       ) {
         throw new Error(
           `single-spa-alpinejs: global function for xInit not found. Optional parameter opts.xInit if provided must be as a function that returns a promise`
         );
       }
-      delete window.singleSpaAlpineXInit[`${appName}`];
+      delete window.singleSpaAlpineXInit[`${normalizedName}`];
     }
   });
 }

--- a/src/single-spa-alpinejs.js
+++ b/src/single-spa-alpinejs.js
@@ -55,10 +55,12 @@ function bootstrap(opts, props) {
 
 /**
  * Remove special characters from the string
- * @param {*} str 
+ * @param {*} str
  */
 function normalizeString(str) {
-  return (str && typeof str === "string")?str.replace(/[^a-z0-9,. ]/gi, '_'):'';
+  return str && typeof str === "string"
+    ? str.replace(/[^a-z0-9,. ]/gi, "_")
+    : "";
 }
 
 /**

--- a/src/single-spa-alpinejs.test.js
+++ b/src/single-spa-alpinejs.test.js
@@ -11,7 +11,9 @@ describe(`single-spa-alpinejs`, () => {
   };
 
   function normalizeString(str) {
-    return (str && typeof str === "string")?str.replace(/[^a-z0-9,. ]/gi, '_'):'';
+    return str && typeof str === "string"
+      ? str.replace(/[^a-z0-9,. ]/gi, "_")
+      : "";
   }
 
   const appOneTemplate = `
@@ -303,7 +305,7 @@ describe(`single-spa-alpinejs`, () => {
     };
     delete window["singleSpaAlpineXInit"];
     const lifecycles = singleSpaAlpinejs(opts);
-    const appProps = { name: '@my/app'}
+    const appProps = { name: "@my/app" };
     const appName = appProps.appName || appProps.name;
     const normalizedAppName = normalizeString(appName);
     return lifecycles
@@ -312,7 +314,9 @@ describe(`single-spa-alpinejs`, () => {
       .then(() => {
         const domEl = domElementAlpineGetter(appProps.name);
         expect(domEl.getAttribute("x-data").trim()).toBe(
-          JSON.stringify(getCombinedProps(appProps, appThreeData(appProps))).trim()
+          JSON.stringify(
+            getCombinedProps(appProps, appThreeData(appProps))
+          ).trim()
         );
         expect(domEl.getAttribute("x-init").trim()).toBe(
           `singleSpaAlpineXInit.${normalizedAppName}('alpine-${appName}')`.trim()


### PR DESCRIPTION
This is the fix for the issue #4 

Also updated the documentation with details of this handling. Here is an excerpt from the documentation to illustrate the change for special character handling

### xData and xInit Handling

- This section covers the details of how `xData` and `xInit` option attributes are processed by the single spa helper.

- Consider the example below

```js
const appDataFn = () => { open: false, loading: true }
const appXInitFn = (domId) => {
	console.log('Hello from appXInitFn');
  // domId provides access to the parent dom element where x-data and x-init are defined
	document.querySelector(`#${domId}`).__x.$data.loading = false
}

const opts = {
  template: appTemplate,	          // base template
  xData: (data) => appDataFn(data), // pass props to x-data
  xInit: appXInitFn,		            // x-Init function
};

const alpinejsApp = singleSpaAlpinejs(opts);

singleSpa.registerApplication({
  name: 'myapp',
  app: alpinejsApp,
  activeWhen: () => true,
});

```

- The helper does the following 
   - Adds the template to the dom wrapped in `parent dom element` with and id that has a prefix of `alpine`. In this case it will be `id='alpine-myapp'` 
   - Attaches a resolved `xData` as a string `x-data="{ "name": "myapp" ,"open": false }"` to the `parent dom element`. 
   - It will make the user defined `appXInitFn` available globally as an attribute of `window.singleSpaAlpineXInit` and will be accessible via variable `window.singleSpaAlpineXInit.myapp` 
   - Attaches a resolved `xInit` as a string that calls the globally defined variable `x-init="singleSpaAlpineXInit.myapp('alpine-myapp')"` to the `parent dom element`.

  - **Note** that this also passes `id` of the `parent dom element` which can then be used to access the alpine data elements to update the state as required.

  #### Special characters in the application names

  - You may have special characters in the application name for example `@my/app`. See the example below

  ```js
   	singleSpa.registerApplication({
    	name: '@my/app',
     	app: alpinejsApp,
     	activeWhen: () => true,
   		});
  ```

  - The single spa helper converts these to valid `global` function names by `replacing` `all the special characters` with underscores (`_`). This does not require any special handling from the user as the helper takes care of this internally

  - In the above case the `xInit` dom element would look like the following `x-init="singleSpaAlpineXInit._my_app('alpine-@my/app')"` where the `xInit` function is available as a `global` variable `_my_app`.
